### PR TITLE
PHP 7.1 + support for api SDK and small tweaks for code readability and unification

### DIFF
--- a/publitio_api.php
+++ b/publitio_api.php
@@ -1,22 +1,48 @@
 <?php
-    /*-----------------------------------------------------------------------------
+    /*
+     * -----------------------------------------------------------------------------
      * PHP SDK for Publitio API
      *
      * Author:      Divjak V.
-     * Copyright:   (c) Publitio https://publit.io/ 
-     * Version:     1.0     
-     *     
+     * Copyright:   (c) Publitio https://publit.io/
+     * Version:     1.0
+     *
      *-----------------------------------------------------------------------------
      */
 
+    /**
+     * Class PublitioAPI
+     */
     class PublitioAPI {
+        /**
+         * @var string $_version
+         */
         private $_version = '1.0';
+
+        /**
+         * @var string $_url
+         */
         private $_url = 'http://api.publit.io/v1';
+
+        /**
+         * @var string $_library
+         */
         private $_library;
 
+        /**
+         * @var string $_key
+         * @var string $_secret
+         */
         private $_key, $_secret;
 
-        public function __construct($key, $secret) {
+        /**
+         * PublitioAPI constructor.
+         *
+         * @param string $key
+         * @param string $secret
+         */
+        public function __construct(string $key, string $secret)
+        {
             $this->_key = $key;
             $this->_secret = $secret;
 
@@ -29,45 +55,73 @@
             }
         }
 
-        public function version() {
+        /**
+         * @return string
+         */
+        public function version(): string
+        {
             return $this->_version;
         }
 
-        // RFC 3986 complient rawurlencode()
-        // Only required for phpversion() <= 5.2.7RC1
-        // See http://www.php.net/manual/en/function.rawurlencode.php#86506
-        private function _urlencode($input) {
+        /**
+         * Encode URL.
+         *
+         * RFC 3986 complient rawurlencode()
+         * Only required for phpversion() <= 5.2.7RC1
+         * @see http://www.php.net/manual/en/function.rawurlencode.php#86506
+         *
+         * @param mixed $input
+         *
+         * @return array|string
+         */
+        private function _urlencode($input)
+        {
             if (is_array($input)) {
                 return array_map(array('_urlencode'), $input);
-            } else if (is_scalar($input)) {
-                return str_replace('+', ' ', str_replace('%7E', '~', rawurlencode($input)));
-            } else {
-                return '';
             }
+
+            if (is_scalar($input)) {
+                return str_replace(array('%7E', '+'), array('~', ' '), rawurlencode($input));
+            }
+
+            return '';
         }
 
-        // Sign API call arguments
-        private function _sign($args) {
+        /**
+         * Sign API call arguments
+         *
+         * @param $args
+         *
+         * @return string
+         */
+        private function _sign(array $args): string
+        {
             ksort($args);
-            $sbs = "";
+            $sbs = '';
             foreach ($args as $key => $value) {
-                if ($sbs != "") {
-                    $sbs .= "&";
+                if ($sbs !== '') {
+                    $sbs .= '&';
                 }
                 // Construct Signature Base String
-                $sbs .= $this->_urlencode($key) . "=" . $this->_urlencode($value);
+                $sbs .= $this->_urlencode($key) . '=' . $this->_urlencode($value);
             }
 
             // Add shared secret to the Signature Base String and generate the signature
-            $signature = sha1($sbs . $this->_secret);
-
-            return $signature;
+            return sha1($sbs . $this->_secret);
         }
 
-        // Add required api_* arguments
-        private function _args($args) {
-            
-            $args['api_nonce'] = str_pad(mt_rand(0, 99999999), 8, STR_PAD_LEFT);
+        /**
+         * Add required api_* arguments
+         *
+         * @param $args
+         *
+         * @return array
+         *
+         * @throws Exception
+         */
+        private function _args(array $args): array
+        {
+            $args['api_nonce'] = str_pad(random_int(0, 99999999), 8, STR_PAD_LEFT);
             $args['api_timestamp'] = time();
             $args['api_key'] = $this->_key;
 
@@ -87,55 +141,82 @@
             return $args;
         }
 
-        // Construct call URL
-        public function call_url($call, $args=array()) {
-            $url = $this->_url . $call . '?' . http_build_query($this->_args($args), "", "&");
+        /**
+         * Construct call URL
+         *
+         * @param string $call
+         * @param array $args
+         *
+         * @return string
+         *
+         * @throws Exception
+         */
+        public function call_url(string $call, array $args = []): string
+        {
+            $url = $this->_url . $call . '?' . http_build_query($this->_args($args), '', '&');
             return $url;
         }
 
-        // Make an API call
-        public function call($call, $method = "GET", $args=array()) {
+        /**
+         * Make an API call
+         *
+         * @param string $call
+         * @param string $method
+         * @param array $args
+         *
+         * @return bool|string
+         *
+         * @throws Exception
+         */
+        public function call(string $call, string $method = 'GET', array $args = [])
+        {
             $url = $this->call_url($call, $args);
 
-            #die($url);
-
             $response = null;
-            switch($this->_library) {
-                case 'curl':
-                    $curl = curl_init();
-                    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);                    
-                    if($method == "PUT") {                   
-                        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
-                    } else if($method == "DELETE") {                   
-                        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
-                    } else if ($method == "POST") {                   
-                        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "POST");
-                    } 
-                    curl_setopt($curl, CURLOPT_URL, $url);
-                    $response = curl_exec($curl);
-                    curl_close($curl);
-                    break;
-                default:
-                    if($method == "GET") 
-                        $response = file_get_contents($url);
-                    else
-                        $response = "Error: No cURL library";
-
+            if ($this->_library === 'curl') {
+                $curl = curl_init();
+                curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+                if ($method === 'PUT') {
+                    curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
+                } else if ($method === 'DELETE') {
+                    curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
+                } else if ($method === 'POST') {
+                    curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'POST');
+                }
+                curl_setopt($curl, CURLOPT_URL, $url);
+                $response = curl_exec($curl);
+                curl_close($curl);
+            } else if ($method === 'GET') {
+                $response = file_get_contents($url);
+            } else {
+                $response = 'Error: No cURL library';
             }
 
             $unserialized_response = @unserialize($response);
 
-            return $unserialized_response ? $unserialized_response : $response;
+            return $unserialized_response ?: $response;
         }
 
-        // Upload a file
-        public function upload_file($file_path, $action = "file", $args=array()) {
-            
-            if ($action=="file")
-            $url = $this->call_url('/files/create', $args);
-            else if ($action=="watermark")
-            $url = $this->call_url('/watermarks/create', $args);
-            #die($url);
+        /**
+         * Upload a file
+         *
+         * @param string $file_path
+         * @param string $action
+         * @param array $args
+         *
+         * @return null|string
+         *
+         * @throws Exception
+         */
+        public function upload_file(string $file_path, string $action = 'file', array $args = []): ?string
+        {
+
+            if ($action === 'file') {
+                $url = $this->call_url('/files/create', $args);
+            }
+            else if ($action === 'watermark') {
+                $url = $this->call_url('/watermarks/create', $args);
+            }
 
             // A new variable included with curl in PHP 5.5 - CURLOPT_SAFE_UPLOAD - prevents the
             // '@' modifier from working for security reasons (in PHP 5.6, the default value is true)
@@ -143,33 +224,31 @@
             // http://php.net/manual/en/migration56.changed-functions.php
             // http://comments.gmane.org/gmane.comp.php.devel/87521
             if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50500) {
-              $post_data = array("file"=>"@" . $file_path);
+              $post_data = array('file' => '@' . $file_path);
             } else {
-              $post_data = array("file"=>new \CURLFile($file_path));
+              $post_data = array('file' => new \CURLFile($file_path));
             }
             $response = null;
 
-            switch($this->_library) {
-                case 'curl':
-                    $curl = curl_init();
-                    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-                    curl_setopt($curl, CURLOPT_URL, $url);
-                    curl_setopt($curl, CURLOPT_POSTFIELDS, $post_data);
-                    $response = curl_exec($curl);
-                    $err_no = curl_errno($curl);
-                    $err_msg = curl_error($curl);
-                    curl_close($curl);
-                    break;
-                default:
-                    $response = "Error: No cURL library";
-            }            
-
-            if ($err_no == 0) {
-                return $response;
+            $i = $this->_library;
+            if ($i === 'curl') {
+                $curl = curl_init();
+                curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt($curl, CURLOPT_URL, $url);
+                curl_setopt($curl, CURLOPT_POSTFIELDS, $post_data);
+                $response = curl_exec($curl);
+                $err_no = curl_errno($curl);
+                $err_msg = curl_error($curl);
+                curl_close($curl);
             } else {
-                return "Error #" . $err_no . ": " . $err_msg;
+                $response = 'Error: No cURL library';
             }
+
+            if ($err_no === 0) {
+                return $response;
+            }
+
+            return 'Error #' . $err_no . ': ' . ($err_msg ?? '');
         }
-        
     }
-?>
+


### PR DESCRIPTION
> PHPDoc support,
> PHP 7+ return type declarations,
> PHP 7.1+ nullable return type declaration,
> Migrated double quoted string to single quoted string, as both were used in current version,
> function _urlencode: cleared up if, elseif, else to more readable double if,
> Removed redundant variable $signature in function: _sign,
> swapped mt_rand for random_int to get a cryptographically secure value in function: _args,
> Removed debug die(); codes, seem unneeded in this (example) SDK,
> Swapped Switch case to clearer if else, as the switch case was behaving as if else in functions: call & upload_file,
> Added strict checking in if statements (===).

**Note:** Only thing pinning this file to a minimum of php 7.1 is the nullable string typehint on line: 211. Feel free to remove this pin to set the pin to a minimum of php 7.0.